### PR TITLE
Fix issues running on Julia 0.5.0 by replacing obsolete type signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 os:
   - linux
-  - osx
 compiler:
   - clang
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.5
 Compat

--- a/src/RIPEMD/RIPEMD.jl
+++ b/src/RIPEMD/RIPEMD.jl
@@ -113,7 +113,7 @@ function transform!(state, block)
   A0, B0, C0, D0, E0 = state
   A1, B1, C1, D1, E1 = state
 
-  X = zeros(Uint32, WORDS_PER_BLOCK)
+  X = zeros(UInt32, WORDS_PER_BLOCK)
 
   for i = 1:WORDS_PER_BLOCK
     X[i] = uint32(block[4 * (i - 1) + 4]) << 24 +
@@ -161,7 +161,7 @@ function ripemd160(msg::ASCIIString; is_hex=false)
 
   if is_hex
     len = int(length(msg) / 2)
-    result = zeros(Uint8, len)
+    result = zeros(UInt8, len)
     for i = 1:len
       result[i] = uint8(parseint(msg[2 * i - 1: 2 * i],16))
     end
@@ -196,11 +196,11 @@ function ripemd160(msg::ASCIIString; is_hex=false)
     # Append k bits '0', where k is the minimum number >= 0 such that the 
     # resulting message length (modulo 512 in bits) is 448.
     if length(msg) > BLOCK_SIZE - 8
-      msg = append!(msg, zeros(Uint8, BLOCK_SIZE - rem))
+      msg = append!(msg, zeros(UInt8, BLOCK_SIZE - rem))
       transform!(state, msg)
-      msg = zeros(Uint8, BLOCK_SIZE)
+      msg = zeros(UInt8, BLOCK_SIZE)
     else
-      msg = append!(msg, zeros(Uint8, BLOCK_SIZE - rem))
+      msg = append!(msg, zeros(UInt8, BLOCK_SIZE - rem))
     end
 
     # Append length of message (without the '1' bit or padding), in bits, as 

--- a/src/SHA2/SHA2.jl
+++ b/src/SHA2/SHA2.jl
@@ -127,7 +127,7 @@ S1(x) = (ROTRIGHT(x, 17) $ ROTRIGHT(x, 19) $ (x >>> 10))
 function transform!(state, block)
 
   # Pre-allocate the message schedule array (64 8-bit words)
-  m = zeros(Uint32, CHUNKS_PER_SCHEDULE)
+  m = zeros(UInt32, CHUNKS_PER_SCHEDULE)
 
   for i = 1:CHUNKS_PER_BLOCK
     m[i] = uint32(block[4 * (i - 1) + 1]) << 24 +
@@ -215,11 +215,11 @@ function sha256(msg::String; is_hex=false)
     # Append k bits '0', where k is the minimum number >= 0 such that the 
     # resulting message length (modulo 512 in bits) is 448.
     if length(msg) > BLOCK_SIZE - 8
-      msg = append!(msg, zeros(Uint8, BLOCK_SIZE - rem))
+      msg = append!(msg, zeros(UInt8, BLOCK_SIZE - rem))
       transform!(state, msg)
-      msg = zeros(Uint8, BLOCK_SIZE)
+      msg = zeros(UInt8, BLOCK_SIZE)
     else
-      msg = append!(msg, zeros(Uint8, BLOCK_SIZE - rem))
+      msg = append!(msg, zeros(UInt8, BLOCK_SIZE - rem))
     end
 
     # Append length of message (without the '1' bit or padding), in bits, as 

--- a/src/digest.jl
+++ b/src/digest.jl
@@ -14,7 +14,7 @@ function cleanup()
   ccall((:EVP_cleanup, "libcrypto"), Void, ())
 end
 
-function digest(name::AbstractString, data::String; is_hex=false)
+function digest(name::AbstractString, data::AbstractString; is_hex=false)
   if is_hex
     L = round(Int,length(data)/2)
     data = [@compat(parse(@compat(UInt8),SubString(data,2*i-1,2*i), 16)) for i in 1:L]

--- a/src/ecdsa.jl
+++ b/src/ecdsa.jl
@@ -25,7 +25,7 @@ function ec_pub_key(priv_key::Array{UInt8}; curve_id = NID_secp256k1, form = UNC
 end
 
 # priv_key as hex string
-function ec_pub_key(priv_key::String; curve_id = NID_secp256k1, form = UNCOMPRESSED)
+function ec_pub_key(priv_key::AbstractString; curve_id = NID_secp256k1, form = UNCOMPRESSED)
   ec_pub_key(hex2bytes(priv_key), curve_id = curve_id, form = form)
 end
 

--- a/src/ecdsa.jl
+++ b/src/ecdsa.jl
@@ -25,7 +25,7 @@ function ec_pub_key(priv_key::Array{UInt8}; curve_id = NID_secp256k1, form = UNC
 end
 
 # priv_key as hex string
-function ec_pub_key(priv_key::ByteString; curve_id = NID_secp256k1, form = UNCOMPRESSED)
+function ec_pub_key(priv_key::String; curve_id = NID_secp256k1, form = UNCOMPRESSED)
   ec_pub_key(hex2bytes(priv_key), curve_id = curve_id, form = form)
 end
 

--- a/src/random.jl
+++ b/src/random.jl
@@ -5,8 +5,8 @@ function random(numbits)
     numbytes += 1
   end
 
-  ret = zeros(Uint8, numbytes)
-  ccall((:RAND_bytes, "libcrypto"), Void, (Ptr{Uint8}, Int), ret, numbytes)
+  ret = zeros(UInt8, numbytes)
+  ccall((:RAND_bytes, "libcrypto"), Void, (Ptr{UInt8}, Int), ret, numbytes)
 
   return ret
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -18,7 +18,7 @@ end
 function oct2hex(hex_array::Array{@compat(UInt8)})
   return join([hex(h, 2) for h in hex_array], "")
 end
-oct2hex(s::ByteString) = oct2hex(s.data)
+oct2hex(s::String) = oct2hex(s.data)
 
 # TODO: String manipulation is really not the best way
 function int2oct(x::Integer)

--- a/src/util.jl
+++ b/src/util.jl
@@ -18,7 +18,7 @@ end
 function oct2hex(hex_array::Array{@compat(UInt8)})
   return join([hex(h, 2) for h in hex_array], "")
 end
-oct2hex(s::String) = oct2hex(s.data)
+oct2hex(s::AbstractString) = oct2hex(s.data)
 
 # TODO: String manipulation is really not the best way
 function int2oct(x::Integer)


### PR DESCRIPTION
Removes deprecated type signatures (Uint8 becomes UInt8 for example).  Tests failed on Julia 0.5.0 prior to changes, tests pass afterwards.  Built on macOS Sierra.
